### PR TITLE
Add deprecation warning for using differently ordered return items in UNIONs

### DIFF
--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -920,6 +920,31 @@ CREATE TEXT INDEX FOR (n:Label) ON (n.prop) OPTIONS {indexProvider : 'text-2.0'}
 ----
 ====
 
+.Using differently ordered return items in a `UNION` clause
+====
+Query::
++
+[source,cypher]
+----
+RETURN 'val' as one, 'val' as two
+UNION
+RETURN 'val' as two, 'val' as one
+----
+
+Description of the returned code::
+All sub queries in a UNION should have the same ordering for the return column names, this is deprecated and will be enforced in later versions.
+
+Suggestions for improvement::
+Use the same order for all branches of a `Union` clause.
++
+[source,cypher]
+----
+RETURN 'val' as one, 'val' as two
+UNION
+RETURN 'val' as one, 'val' as two
+----
+====
+
 [#_neo_clientnotification_request_deprecatedformat]
 === Neo.ClientNotification.Request.DeprecatedFormat
 

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -932,10 +932,12 @@ RETURN 'val' as two, 'val' as one
 ----
 
 Description of the returned code::
-All sub queries in a UNION should have the same ordering for the return column names, this is deprecated and will be enforced in later versions.
+All subqueries in a UNION [ALL] should have the same ordering for the return columns.
+Using differently ordered return items in a UNION [ALL] clause is deprecated and will not be possible in future versions.
 
 Suggestions for improvement::
-Use the same order for all branches of a `Union` clause.
+Use the same order for the return columns in all subqueries combined by a `UNION` clause.
+
 +
 [source,cypher]
 ----

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -933,7 +933,7 @@ RETURN 'val' as two, 'val' as one
 
 Description of the returned code::
 All subqueries in a UNION [ALL] should have the same ordering for the return columns.
-Using differently ordered return items in a UNION [ALL] clause is deprecated and will not be possible in future versions.
+Using differently ordered return items in a UNION [ALL] clause is deprecated and will be removed in a future version.
 
 Suggestions for improvement::
 Use the same order for the return columns in all subqueries combined by a `UNION` clause.


### PR DESCRIPTION
Based on this PR: https://github.com/neo-technology/neo4j/pull/18935/files