### PR TITLE
Deprecate id() function

### DIFF
--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -895,7 +895,7 @@ MATCH (a)
 RETURN id(a)
 ----
 Description of the returned code::
-The function id() is deprecated. Use the function elementId() instead.
+The query used a deprecated function. ('id' is no longer supported)
 Suggestions for improvement::
 Use the function `elementId` instead.
 +

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -885,6 +885,27 @@ RETURN 'val' as one, 'val' as two
 ----
 ====
 
+.Using id() function
+====
+Query::
++
+[source,cypher]
+----
+MATCH (a)
+RETURN id(a)
+----
+Description of the returned code::
+The function id() is deprecated. Use the function elementId() instead.
+Suggestions for improvement::
+Use the function `elementId` instead.
++
+[source,cypher]
+----
+MATCH (a)
+RETURN elementId(a)
+----
+====
+
 [#_neo_clientnotification_request_deprecatedformat]
 === Neo.ClientNotification.Request.DeprecatedFormat
 

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -897,7 +897,7 @@ RETURN id(a)
 Description of the returned code::
 The query used a deprecated function. ('id' is no longer supported)
 Suggestions for improvement::
-Use the function `elementId` instead.
+Use the function `elementId()` instead.
 +
 [source,cypher]
 ----


### PR DESCRIPTION
The id() function has been deprecated since 5.0 but only in the docs. It will now be added in the code as well, hence the new notification.