### PR TITLE
Add `CordonedServersExistedDuringAllocation` notification

### DIFF
--- a/modules/ROOT/pages/changelogs.adoc
+++ b/modules/ROOT/pages/changelogs.adoc
@@ -7,6 +7,7 @@
 
 [source, status codes, role="noheader"]
 -----
+Neo.ClientNotification.Cluster.CordonedServersExistedDuringAllocation
 Neo.ClientNotification.Cluster.NoDatabasesReallocated
 Neo.ClientNotification.Statement.SideEffectVisibility
 -----

--- a/modules/ROOT/pages/changelogs.adoc
+++ b/modules/ROOT/pages/changelogs.adoc
@@ -1,13 +1,21 @@
 :description: This page lists all changes to status codes per Neo4j version.
 = Changes to status codes per Neo4j version
 
-== Neo4j 5.14
+== Neo4j 5.15
 
 **New:**
 
 [source, status codes, role="noheader"]
 -----
 Neo.ClientNotification.Cluster.CordonedServersExistedDuringAllocation
+-----
+
+== Neo4j 5.14
+
+**New:**
+
+[source, status codes, role="noheader"]
+-----
 Neo.ClientNotification.Cluster.NoDatabasesReallocated
 Neo.ClientNotification.Statement.SideEffectVisibility
 -----

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1316,7 +1316,7 @@ CREATE DATABASE foo TOPOLOGY 2 PRIMARIES
 ----
 
 Description of the returned code::
-The following server(s) are cordoned `123e4567-e89b-12d3-a456-426614174000`. This can impact allocation decisions.
+Server(s) `123e4567-e89b-12d3-a456-426614174000` are cordoned. This can impact allocation decisions.
 ====
 
 [#_neo_clientnotification_cluster_nodatabasesreallocated]

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1306,7 +1306,7 @@ m|TOPOLOGY
 
 .Cordoned servers existed during an allocation decision
 ====
-For example, consider a cluster with three servers, of which server `123e4567-e89b-12d3-a456-426614174000` has been cordoned using the `dbms.cluster.cordonServer` procedure. Then the below command will return this notification.
+The example assumes that you have a cluster with three servers, of which server `123e4567-e89b-12d3-a456-426614174000` is cordoned using the `dbms.cluster.cordonServer` procedure. Then the below command will return this notification.
 
 Command::
 +

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1299,7 +1299,7 @@ m|TOPOLOGY
 .Cordoned servers existed during an allocation decision
 ====
 This notification will be returned by any command that triggers an allocation decision. Examples are `CREATE DATABASE`, `ALTER DATABASE`, `DEALLOCATE DATABASES FROM SERVER`, `ALTER DATABASE`.
-Note, `REALLOCATE DATABASES` requires there to be no cordoned servers to be executed successfully thus will never not return this notification.
+Note, `REALLOCATE DATABASES` requires there to be no cordoned servers to be executed successfully thus will never return this notification.
 
 For example, consider a cluster with three servers, of which server `123e4567-e89b-12d3-a456-426614174000` has been cordoned using the `dbms.cluster.cordonServer` procedure. Then the below command will return this notification.
 

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1281,6 +1281,39 @@ Use `DATABASE *` without the parameter to revoke the privilege on all databases.
 
 Topology notifications provide additional information related to managing databases and servers.
 
+[#_neo_clientnotification_cluster_cordonedserversexistedduringallocation]
+=== CordonedServersExistedDuringAllocation
+.Notification details
+[cols="<1s,<4"]
+|===
+|Code
+m|Neo.ClientNotification.Cluster.CordonedServersExistedDuringAllocation
+|Title
+a| Cordoned servers existed when making an allocation decision.
+|Severity
+m|WARNING
+|Category
+m|TOPOLOGY
+|===
+
+.Cordoned servers existed during an allocation decision
+====
+This notification will be returned by any command that triggers an allocation decision. Examples are `CREATE DATABASE`, `ALTER DATABASE`, `DEALLOCATE DATABASES FROM SERVER`, `ALTER DATABASE`.
+Note, `REALLOCATE DATABASES` requires there to be no cordoned servers to be executed successfully thus will never not return this notification.
+
+For example, consider a cluster with three servers, of which server `123e4567-e89b-12d3-a456-426614174000` has been cordoned using the `dbms.cluster.cordonServer` procedure. Then the below command will return this notification.
+
+Command::
++
+[source, cypher]
+----
+CREATE DATABASE foo TOPOLOGY 2 PRIMARIES
+----
+
+Description of the returned code::
+The following server(s) are cordoned `123e4567-e89b-12d3-a456-426614174000`. This can impact allocation decisions.
+====
+
 [#_neo_clientnotification_cluster_nodatabasesreallocated]
 === NoDatabasesReallocated
 

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1283,6 +1283,14 @@ Topology notifications provide additional information related to managing databa
 
 [#_neo_clientnotification_cluster_cordonedserversexistedduringallocation]
 === CordonedServersExistedDuringAllocation
+
+.When is this notification returned?
+[TIP]
+====
+When a Cypher administration command triggers an allocation decision and some of the servers are cordoned.
+For example, `CREATE DATABASE`, `ALTER DATABASE`, `DEALLOCATE DATABASES FROM SERVER[S]`, and `ALTER DATABASE` return this notification. However, `REALLOCATE DATABASES` requires that there are no cordoned servers and, therefore, does not return it.
+====
+
 .Notification details
 [cols="<1s,<4"]
 |===
@@ -1298,9 +1306,6 @@ m|TOPOLOGY
 
 .Cordoned servers existed during an allocation decision
 ====
-This notification will be returned by any command that triggers an allocation decision. Examples are `CREATE DATABASE`, `ALTER DATABASE`, `DEALLOCATE DATABASES FROM SERVER`, `ALTER DATABASE`.
-Note, `REALLOCATE DATABASES` requires there to be no cordoned servers to be executed successfully thus will never return this notification.
-
 For example, consider a cluster with three servers, of which server `123e4567-e89b-12d3-a456-426614174000` has been cordoned using the `dbms.cluster.cordonServer` procedure. Then the below command will return this notification.
 
 Command::

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1291,7 +1291,7 @@ m|Neo.ClientNotification.Cluster.CordonedServersExistedDuringAllocation
 |Title
 a| Cordoned servers existed when making an allocation decision.
 |Severity
-m|WARNING
+m|INFORMATION
 |Category
 m|TOPOLOGY
 |===

--- a/modules/ROOT/pages/notifications/index.adoc
+++ b/modules/ROOT/pages/notifications/index.adoc
@@ -60,7 +60,7 @@ The following categories exist, ordered by severity:
 | Make sure that the behaviour is what you intended.
 
 | TOPOLOGY
-| WARNING OR INFORMATION
+| INFORMATION
 | Information provided while executing database and server related commands.
 |
 

--- a/modules/ROOT/pages/notifications/index.adoc
+++ b/modules/ROOT/pages/notifications/index.adoc
@@ -60,7 +60,7 @@ The following categories exist, ordered by severity:
 | Make sure that the behaviour is what you intended.
 
 | TOPOLOGY
-| INFORMATION
+| WARNING OR INFORMATION
 | Information provided while executing database and server related commands.
 |
 


### PR DESCRIPTION
https://trello.com/c/1ymz1Qiq/975-create-a-notification-when-doing-allocations-while-some-servers-are-cordoned

This PR proposes the introduction of the `CordonedServersExistedDuringAllocation` notification. This will be returned whenever a command that triggers a database allocation decision is executed. This includes `CREATE DATABASE`, `ALTER DATABASE`, `DEALLOCATE DATABASES FROM SERVER`, `ALTER SERVER`. But not `REALLOCATE DATABASES` as this command has the requirement for no cordoned servers and errors if there is such a server. 

This is useful to remind the person managing the cluster that some servers are cordoned and this impacts the allocation decision (databases can't be allocated to cordoned servers). So this should help the user not get confused by the allocation decisions made.

I have included this as a `WARNING` initially but maybe `INFORMATION` would be better suited, not sure on the criteria to be made a `WARNING`. Cordoned servers aren't necessarily a bad thing in themselves but their existence could lead to "worse" allocation decision than if they were uncordoned. So, the warning could be seen as a prompt the user to do something about the cordoned server. 