### PR TITLE
Add `RequestedTopologyMatchedCurrentTopology` notification

### DIFF
--- a/modules/ROOT/pages/changelogs.adoc
+++ b/modules/ROOT/pages/changelogs.adoc
@@ -1,6 +1,15 @@
 :description: This page lists all changes to status codes per Neo4j version.
 = Changes to status codes per Neo4j version
 
+== Neo4j 5.17
+
+**New:**
+
+[source, status codes, role="noheader"]
+-----
+Neo.ClientNotification.Cluster.RequestedTopologyMatchedCurrentTopology
+-----
+
 == Neo4j 5.15
 
 **New:**

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1368,6 +1368,38 @@ For example, when there are three servers, each hosting databases `foo` and `bar
 **Scenario 2:** The cluster appears unbalanced, but server constraints prevent you from moving to a better, more balanced, allocation. For example, assuming server 1 hosts databases `foo` and `bar`, server 2 hosts only `foo`, and server 3 hosts no databases. Then, a better allocation would move `foo` from server 1 to server 3, but if server 3 has the constraint `deniedDatabases:['foo']}`, then the cluster is already balanced subject to this constraint.
 ====
 
+[#_neo_clientnotification_cluster_requestedtopologymatchedcurrenttopology]
+=== RequestedTopologyMatchedCurrentTopology
+
+.Notification details
+[cols="<1s,<4"]
+|===
+|Code
+m|Neo.ClientNotification.Cluster.RequestedTopologyMatchedCurrentTopology
+|Title
+a| `<command>` has no effect.
+|Severity
+m|INFORMATION
+|Category
+m|TOPOLOGY
+|===
+
+.Requested topology matched current topology 
+====
+The example assumes that you have a cluster with three servers and a database `foo` with a topology of two primaries and one secondary. Then the below command will return this notification.
+
+Command::
++
+[source, cypher]
+----
+ALTER DATABASE foo SET TOPOLOGY 2 PRIMARIES 1 SECONDARY
+----
+
+Description of the returned code::
+The requested topology matched the current topology. No allocations were changed.
+====
+
+
 [#_neo_clientnotification_cluster_serveralreadyenabled]
 === ServerAlreadyEnabled
 

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1365,7 +1365,9 @@ Example scenarios::
 For example, when there are three servers, each hosting databases `foo` and `bar`, meaning all databases are allocated to all servers.
 +
 
-**Scenario 2:** The cluster appears unbalanced, but server constraints prevent you from moving to a better, more balanced, allocation. For example, assuming server 1 hosts databases `foo` and `bar`, server 2 hosts only `foo`, and server 3 hosts no databases. Then, a better allocation would move `foo` from server 1 to server 3, but if server 3 has the constraint `deniedDatabases:['foo']}`, then the cluster is already balanced subject to this constraint.
+**Scenario 2:** The cluster appears unbalanced, but server constraints prevent you from moving to a better, more balanced, allocation. 
+For example, assuming server 1 hosts databases `foo` and `bar`, server 2 hosts only `foo`, and server 3 hosts no databases.
+Then, a better allocation would move `foo` from server 1 to server 3, but if server 3 has the constraint `deniedDatabases:['foo']}`, then the cluster is already balanced subject to this constraint.
 ====
 
 [#_neo_clientnotification_cluster_requestedtopologymatchedcurrenttopology]

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1388,7 +1388,7 @@ m|TOPOLOGY
 
 .Requested topology matched current topology 
 ====
-The example assumes that you have a cluster with three servers and a database `foo` with a topology of two primaries and one secondary. Then the below command will return this notification.
+The example assumes that you have a cluster with three servers and a database `foo` with a topology of two primaries and one secondary. 
 
 Command::
 +


### PR DESCRIPTION
https://trello.com/c/U9hshewv/1069-alter-database-notification-when-requested-topology-matches-current-topology

This PR proposes the introduction of the `RequestedTopologyMatchedCurrentTopology` notification. This will be returned when an `ALTER DATABASE` command matches the current topology so no allocations are removed/added, e.g., foo has 2 primaries and 1 secondary then I issue an `ALTER DATABASE foo 2 PRIMARIES 1 SECONDARY`.