### PR TITLE
Typo causing broken link

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -231,7 +231,7 @@
 **** xref:errors/gql-errors/42N21.adoc[]
 **** xref:errors/gql-errors/42N22.adoc[]
 **** xref:errors/gql-errors/42N24.adoc[]
-**** xref:errors/gql-errors/42I26.adoc[]
+**** xref:errors/gql-errors/42N26.adoc[]
 **** xref:errors/gql-errors/42N28.adoc[]
 **** xref:errors/gql-errors/42N29.adoc[]
 **** xref:errors/gql-errors/42N31.adoc[]


### PR DESCRIPTION
This error's link (https://neo4j.com/docs/status-codes/current/errors/gql-errors/#_42n26) is not working because it's not listed in the content-nav file due to a typo.