### PR TITLE
Error missing in the content-nav

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -433,6 +433,7 @@
 **** xref:errors/gql-errors/52N24.adoc[]
 **** xref:errors/gql-errors/52N25.adoc[]
 **** xref:errors/gql-errors/52N26.adoc[]
+**** xref:errors/gql-errors/52N27.adoc[]
 **** xref:errors/gql-errors/52N28.adoc[]
 **** xref:errors/gql-errors/52N29.adoc[]
 **** xref:errors/gql-errors/52N30.adoc[]


### PR DESCRIPTION
Causing broken link.
It's also being addressed in the main branch using this PR https://github.com/neo4j/docs-status-codes/pull/293, so no need to cherry-pick it.