### PR TITLE
Add new GQLSTATUS 22NBA

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -151,6 +151,7 @@
 **** xref:errors/gql-errors/22NB7.adoc[]
 **** xref:errors/gql-errors/22NB8.adoc[]
 **** xref:errors/gql-errors/22NB9.adoc[]
+**** xref:errors/gql-errors/22NBA.adoc[]
 *** xref:errors/gql-errors/index.adoc#invalid-transaction-state[Invalid transaction state]
 **** xref:errors/gql-errors/25G02.adoc[]
 **** xref:errors/gql-errors/25N01.adoc[]

--- a/modules/ROOT/pages/errors/gql-errors/22NBA.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/22NBA.adoc
@@ -1,0 +1,27 @@
+= 22NBA
+
+== Status description
+
+error: data exception - omitting mandatory field for property type constraints for vectors. Property type constraints for vectors need to define both coordinate type and dimension.
+
+== Example scenario
+
+For example, try to create a property type constraint for a vector, omitting the dimension:
+
+[source,cypher]
+----
+CREATE CONSTRAINT myConstraint
+FOR (n:Label)
+REQUIRE n.prop IS :: VECTOR<INTEGER>
+----
+
+You will receive an error with GQLSTATUS xref:errors/gql-errors/50N11.adoc[50N11].
+This error has a cause detailed in xref:errors/gql-errors/22N90.adoc[22N90], which also has a subsequent cause with GQLSTATUS 22NBA and the status description above.
+
+
+ifndef::backend-pdf[]
+[discrete.glossary]
+== Glossary
+
+include::partial$glossary.adoc[]
+endif::[]


### PR DESCRIPTION
Corresponding Neo4j PR: https://github.com/neo-technology/neo4j/pull/31193 

I tried to follow the same pattern as for 22NB9, but I did not know if it made sense to write out the status description in the example, given that it does not have any parameters.

Also note, that while the Neo4j PR will be included in 2025.06, the vector feature is still under a feature flag so I am not entirely sure about the version for this docs PR