### PR TITLE
Update deprecation message for legacy text index providers.

### DIFF
--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1575,7 +1575,7 @@ Please use a path with a length of 1 [r*1..1] instead or a Match with a limit.
 - The query used a deprecated function. (`%s`)
 - The query used a deprecated procedure. (`%s`)
 - The query used a deprecated runtime option. (`%s`)
-- The `TextIndexProvider.DESCRIPTOR.name()` provider for text indexes is deprecated and will be removed in a future version.
+- `text-1.0`, `text-2.0` providers for text indexes are deprecated and will be removed in a future version. Please use `text-3.0` instead.
 Please use `TrigramIndexProvider.DESCRIPTOR.name()` instead.
 |Category
 m|DEPRECATION

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1575,7 +1575,7 @@ Please use a path with a length of 1 [r*1..1] instead or a Match with a limit.
 - The query used a deprecated function. (`%s`)
 - The query used a deprecated procedure. (`%s`)
 - The query used a deprecated runtime option. (`%s`)
-- `text-1.0`, `text-2.0` providers for text indexes are deprecated and will be removed in a future version. Please use `text-3.0` instead.
+-  label:new[Changed in 2025.09] `text-1.0`, `text-2.0` providers for text indexes are deprecated and will be removed in a future version. Please use `text-3.0` instead.
 |Category
 m|DEPRECATION
 |GQLSTATUS code

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1575,7 +1575,8 @@ Please use a path with a length of 1 [r*1..1] instead or a Match with a limit.
 - The query used a deprecated function. (`%s`)
 - The query used a deprecated procedure. (`%s`)
 - The query used a deprecated runtime option. (`%s`)
--  label:new[Changed in 2025.09] `text-1.0`, `text-2.0` providers for text indexes are deprecated and will be removed in a future version. Please use `text-3.0` instead.
+-  `text-1.0` and `text-2.0` (from Neo4j 2025.09 onwards) providers for text indexes are deprecated and will be removed in a future version.
+Please use `text-3.0` instead.
 |Category
 m|DEPRECATION
 |GQLSTATUS code

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1576,7 +1576,6 @@ Please use a path with a length of 1 [r*1..1] instead or a Match with a limit.
 - The query used a deprecated procedure. (`%s`)
 - The query used a deprecated runtime option. (`%s`)
 - `text-1.0`, `text-2.0` providers for text indexes are deprecated and will be removed in a future version. Please use `text-3.0` instead.
-Please use `TrigramIndexProvider.DESCRIPTOR.name()` instead.
 |Category
 m|DEPRECATION
 |GQLSTATUS code


### PR DESCRIPTION
Since text-2.0 index provider is legacy now.  
Also, fix the message:)