### PR TITLE
Introduces 42I79

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -299,6 +299,7 @@
 **** xref:errors/gql-errors/42I74.adoc[]
 **** xref:errors/gql-errors/42I75.adoc[]
 **** xref:errors/gql-errors/42I78.adoc[]
+**** xref:errors/gql-errors/42I79.adoc[]
 **** xref:errors/gql-errors/42N00.adoc[]
 **** xref:errors/gql-errors/42N01.adoc[]
 **** xref:errors/gql-errors/42N02.adoc[]

--- a/modules/ROOT/pages/errors/gql-errors/42I79.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I79.adoc
@@ -4,25 +4,25 @@
 error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause { <<argList>> }.
 
 == Explanation
-A subclause expression is an expression in a subclause, e.g. ORDER BY or WHERE, that belongs to a projection clause.
-If that expression is aggregating it is not allowed to reference aliases introduced in the same projection clause,
-only variables incoming to the clause.
+A subclause expression is an expression used in a subclause (e.g., `WHERE` or `ORDER BY`) that belongs to a projection clause.
+If that expression is aggregating, it is not allowed to reference aliases introduced in the same projection clause; only variables incoming to the clause are allowed.
 
 == Example scenario
-For example, sorting by an aggregation over a variable that the same `RETURN` clause introduces:
+Try sorting by an aggregation over a variable that the same `RETURN` clause introduces:
 
 .Aggregates over parity, which is declared in the same clause
 [source,cypher]
 ----
 UNWIND [1, 2, 3, 4] AS x
 RETURN x % 2 AS parity, sum(x) AS total
-  ORDER BY sum(parity)
+  ORDER BY sum(parity);
 ----
 
 `sum(parity)` is an aggregation, and `parity` is introduced by the same `RETURN` clause.
-An error will be thrown with GQLSTATUS 42I79 and the following status description:
+The query returns an error with GQLSTATUS 42I79 and status description:
 
-[source]
+.GQLSTATUS error
+[source, error]
 
 ----
 error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause parity.
@@ -34,34 +34,31 @@ To resolve this issue, aggregate over the underlying incoming expression instead
 
 .Aggregates over the underlying expression x % 2
 [source,cypher]
-
 ----
 UNWIND [1, 2, 3, 4] AS x
 RETURN x % 2 AS parity, sum(x) AS total
-  ORDER BY sum(x % 2)
+  ORDER BY sum(x % 2);
 ----
 
 Alternatively, compute the value in a preceding clause so it is an incoming variable rather than one declared in the same clause:
 
 .Introduces parity in an earlier clause
 [source,cypher]
-
 ----
 UNWIND [1, 2, 3, 4] AS x
 LET parity = x % 2
 RETURN parity, sum(x) AS total
-  ORDER BY sum(parity)
+  ORDER BY sum(parity);
 ----
 
 If the aggregation is meant to reuse a value already projected by the clause, reference that return item by its alias without re-aggregating it:
 
 .Sorts by the existing total aggregation
 [source,cypher]
-
 ----
 UNWIND [1, 2, 3, 4] AS x
 RETURN x % 2 AS parity, sum(x) AS total
-  ORDER BY total
+  ORDER BY total;
 ----
 
 ifndef::backend-pdf[]

--- a/modules/ROOT/pages/errors/gql-errors/42I79.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I79.adoc
@@ -1,0 +1,72 @@
+= 42I79
+
+== Status description
+error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause { <<argList>> }.
+
+== Explanation
+A subclause expression is an expression in a subclause, e.g. ORDER BY or WHERE, that belongs to a projection clause.
+If that expression is aggregating it is not allowed to reference aliases introduced in the same projection clause,
+only variables incoming to the clause.
+
+== Example scenario
+For example, sorting by an aggregation over a variable that the same `RETURN` clause introduces:
+
+.Aggregates over parity, which is declared in the same clause
+[source,cypher]
+----
+UNWIND [1, 2, 3, 4] AS x
+RETURN x % 2 AS parity, sum(x) AS total
+  ORDER BY sum(parity)
+----
+
+`sum(parity)` is an aggregation, and `parity` is introduced by the same `RETURN` clause.
+An error will be thrown with GQLSTATUS 42I79 and the following status description:
+
+[source]
+
+----
+error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause parity.
+----
+
+== Possible solutions
+
+To resolve this issue, aggregate over the underlying incoming expression instead of the same-clause alias:
+
+.Aggregates over the underlying expression x % 2
+[source,cypher]
+
+----
+UNWIND [1, 2, 3, 4] AS x
+RETURN x % 2 AS parity, sum(x) AS total
+  ORDER BY sum(x % 2)
+----
+
+Alternatively, compute the value in a preceding clause so it is an incoming variable rather than one declared in the same clause:
+
+.Introduces parity in an earlier clause
+[source,cypher]
+
+----
+UNWIND [1, 2, 3, 4] AS x
+LET parity = x % 2
+RETURN parity, sum(x) AS total
+  ORDER BY sum(parity)
+----
+
+If the aggregation is meant to reuse a value already projected by the clause, reference that return item by its alias without re-aggregating it:
+
+.Sorts by the existing total aggregation
+[source,cypher]
+
+----
+UNWIND [1, 2, 3, 4] AS x
+RETURN x % 2 AS parity, sum(x) AS total
+  ORDER BY total
+----
+
+ifndef::backend-pdf[]
+[discrete.glossary]
+== Glossary
+
+include::partial$glossary.adoc[]
+endif::[]

--- a/modules/ROOT/pages/errors/gql-errors/42I79.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I79.adoc
@@ -1,7 +1,7 @@
 = 42I79
 
 == Status description
-error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause { <<argList>> }.
+error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause `{ <<argList>> }`.
 
 == Explanation
 A subclause expression is an expression used in a subclause (e.g., `WHERE` or `ORDER BY`) that belongs to a projection clause.

--- a/modules/ROOT/pages/errors/gql-errors/42I79.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I79.adoc
@@ -19,13 +19,17 @@ RETURN x % 2 AS parity, sum(x) AS total
 ----
 
 `sum(parity)` is an aggregation, and `parity` is introduced by the same `RETURN` clause.
-The query returns an error with GQLSTATUS 42I79 and status description:
 
-.GQLSTATUS error
+The query returns a chain of errors where GQLSTATUS 42I79 is the cause of GQLSTATUS xref:errors/gql-errors/42001.adoc[42001]:
+
+.GQLSTATUS error chain
 [source, error]
 
 ----
-error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause parity.
+42I79: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause: `parity`. (line 3, column 12 (offset: 76))
+"  ORDER BY sum(parity)"
+            ^
+  42001: syntax error or access rule violation - invalid syntax
 ----
 
 == Possible solutions

--- a/modules/ROOT/pages/errors/gql-errors/index.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/index.adoc
@@ -1211,6 +1211,10 @@ Status description:: error: syntax error or access rule violation - index or con
 
 Status description:: error: syntax error or access rule violation - unsupported procedure or function in language version. The procedure or function is available in `CYPHER { <<version>> }`. Consider changing the database default Cypher version using `ALTER DATABASE SET DEFAULT LANGUAGE` or prefix the query with `CYPHER { <<version>> }`.
 
+=== xref:errors/gql-errors/42I79.adoc[42I79]
+
+Status description:: error: syntax error or access rule violation - invalid reference in subclause expression. Aggregation in subclause expression is not allowed to reference variables declared in the same clause `{ <<argList>> }`.
+
 === xref:errors/gql-errors/42N00.adoc[42N00]
 
 Status description:: error: syntax error or access rule violation - graph reference not found. A graph reference with the name `{ <<db>> }` was not found. Verify that the spelling is correct.


### PR DESCRIPTION
Introduces `42I79 - invalid reference in subclause expression` as part of CIP-248 and [PR](https://github.com/neo-technology/neo4j/pull/37728).