### PR TITLE
Updated 42N44

### DIFF
--- a/modules/ROOT/pages/errors/gql-errors/42N44.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42N44.adoc
@@ -4,13 +4,13 @@
 error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using { <<groupingConstructs>> }.
 
 == Explanation
-A `WITH` or `RETURN` clause that uses `DISTINCT`, an aggregation, or a `GROUP BY` clause defines a new set of available variables: the grouping keys, projection item aliases and the aggregation results.
-Any of its subclauses (`ORDER BY`, `WHERE`) can therefore only reference those grouping keys, projection item aliases, and aggregation results, not the variables that were in scope before the clause.
-Referencing a variable that was declared before such a clause, and that is neither a grouping key, projection item alias nor an aggregation result, is not possible and results in this error.
+A `WITH` or `RETURN` clause that uses `DISTINCT`, an aggregation, or a `GROUP BY` clause defines a new set of available variables: grouping keys, projection item aliases, and aggregation results.
+Any of its subclauses (`ORDER BY`, `WHERE`) can therefore only reference those grouping keys, projection item aliases, and aggregation results, not the variables that are in scope before the clause.
+Referencing a variable that is declared before such a clause, and that is not a grouping key, projection item alias, or an aggregation result, is not possible and results in this error.
 
 == Example scenario
 
-For example, the following query groups by `a` and aggregates with `count(*)`, but then tries to sort on `b`, which is neither a grouping key, projection item, nor an aggregation result:
+Try grouping by `a` and aggregating with `count(*)`, but then sorting on `b`, which is not a grouping key, projection item, or an aggregation result:
 
 [source,cypher]
 ----
@@ -18,15 +18,16 @@ UNWIND [{a: 1, b: 10}, {a: 1, b: 20}, {a: 2, b: 30}] AS row
 WITH row.a AS a, row.b AS b
 RETURN a, count(*) AS cnt
   GROUP BY a
-  ORDER BY b
+  ORDER BY b;
 ----
 
-Because `b` was declared before the `RETURN` clause and is not part of the grouping, it cannot be accessed in the `ORDER BY` subclause.
-You will receive an error with GQLSTATUS 42N44 and status description:
+Because `b` is declared before the `RETURN` clause and is not part of the grouping, it cannot be accessed by the `ORDER BY` subclause.
+The query returns an error with GQLSTATUS 42N44 and status description:
 
-[source]
+.GQLSTATUS error
+[source, error]
 ----
-error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using `DISTINCT`, an aggregation, or a `GROUP BY` clause.
+42N44: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using `DISTINCT`, an aggregation, or a `GROUP BY` clause.
 ----
 
 To resolve the error, either add `b` as a grouping key (`GROUP BY a, b`), or order by a grouping key or aggregation result (for example, `ORDER BY a` or `ORDER BY cnt`).

--- a/modules/ROOT/pages/errors/gql-errors/42N44.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42N44.adoc
@@ -1,11 +1,35 @@
 = 42N44
 
-
 == Status description
-error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using `DISTINCT` or an aggregation.
+error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using { <<groupingConstructs>> }.
 
+== Explanation
+A `WITH` or `RETURN` clause that uses `DISTINCT`, an aggregation, or a `GROUP BY` clause defines a new set of available variables: the grouping keys, projection item aliases and the aggregation results.
+Any of its subclauses (`ORDER BY`, `WHERE`) can therefore only reference those grouping keys, projection item aliases, and aggregation results, not the variables that were in scope before the clause.
+Referencing a variable that was declared before such a clause, and that is neither a grouping key, projection item alias nor an aggregation result, is not possible and results in this error.
 
+== Example scenario
 
+For example, the following query groups by `a` and aggregates with `count(*)`, but then tries to sort on `b`, which is neither a grouping key, projection item, nor an aggregation result:
+
+[source,cypher]
+----
+UNWIND [{a: 1, b: 10}, {a: 1, b: 20}, {a: 2, b: 30}] AS row
+WITH row.a AS a, row.b AS b
+RETURN a, count(*) AS cnt
+  GROUP BY a
+  ORDER BY b
+----
+
+Because `b` was declared before the `RETURN` clause and is not part of the grouping, it cannot be accessed in the `ORDER BY` subclause.
+You will receive an error with GQLSTATUS 42N44 and status description:
+
+[source]
+----
+error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using `DISTINCT`, an aggregation, or a `GROUP BY` clause.
+----
+
+To resolve the error, either add `b` as a grouping key (`GROUP BY a, b`), or order by a grouping key or aggregation result (for example, `ORDER BY a` or `ORDER BY cnt`).
 
 ifndef::backend-pdf[]
 [discrete.glossary]

--- a/modules/ROOT/pages/errors/gql-errors/42N44.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42N44.adoc
@@ -1,16 +1,16 @@
 = 42N44
 
 == Status description
-error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using { <<groupingConstructs>> }.
+error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using `{ <<groupingConstructs>> }`.
 
 == Explanation
 A `WITH` or `RETURN` clause that uses `DISTINCT`, an aggregation, or a `GROUP BY` clause defines a new set of available variables: grouping keys, projection item aliases, and aggregation results.
-Any of its subclauses (`ORDER BY`, `WHERE`) can therefore only reference those grouping keys, projection item aliases, and aggregation results, not the variables that are in scope before the clause.
+Any of its subclauses (`ORDER BY`, `WHERE`) can therefore reference only those grouping keys, projection item aliases, and aggregation results, not the variables that are in scope before the clause.
 Referencing a variable that is declared before such a clause, and that is not a grouping key, projection item alias, or an aggregation result, is not possible and results in this error.
 
 == Example scenario
 
-Try grouping by `a` and aggregating with `count(*)`, but then sorting on `b`, which is not a grouping key, projection item, or an aggregation result:
+Try grouping by `a` and aggregating with `count(*)`, and then sorting on `b`, which is not a grouping key, a projection item, or an aggregation result:
 
 [source,cypher]
 ----
@@ -27,10 +27,20 @@ The query returns an error with GQLSTATUS 42N44 and status description:
 .GQLSTATUS error
 [source, error]
 ----
-42N44: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using `DISTINCT`, an aggregation, or a `GROUP BY` clause.
+42N44: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using DISTINCT, an aggregation, or a GROUP BY clause.
 ----
 
 To resolve the error, either add `b` as a grouping key (`GROUP BY a, b`), or order by a grouping key or aggregation result (for example, `ORDER BY a` or `ORDER BY cnt`).
+For example:
+
+[source,cypher]
+----
+UNWIND [{a: 1, b: 10}, {a: 1, b: 20}, {a: 2, b: 30}] AS row
+WITH row.a AS a, row.b AS b
+RETURN a, count(*) AS cnt
+  GROUP BY a, b
+  ORDER BY b;
+----
 
 ifndef::backend-pdf[]
 [discrete.glossary]

--- a/modules/ROOT/pages/errors/gql-errors/42N44.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42N44.adoc
@@ -22,12 +22,15 @@ RETURN a, count(*) AS cnt
 ----
 
 Because `b` is declared before the `RETURN` clause and is not part of the grouping, it cannot be accessed by the `ORDER BY` subclause.
-The query returns an error with GQLSTATUS 42N44 and status description:
+The query returns a chain of errors where GQLSTATUS 42N44 is the cause of GQLSTATUS xref:errors/gql-errors/42001.adoc[42001]:
 
-.GQLSTATUS error
+.GQLSTATUS error chain
 [source, error]
 ----
-42N44: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using DISTINCT, an aggregation, or a GROUP BY clause.
+42N44: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `b` declared before the RETURN clause when using `DISTINCT`, an aggregation, or a `GROUP BY` clause. (line 5, column 12 (offset: 138))
+"  ORDER BY b"
+            ^
+  42001: syntax error or access rule violation - invalid syntax
 ----
 
 To resolve the error, either add `b` as a grouping key (`GROUP BY a, b`), or order by a grouping key or aggregation result (for example, `ORDER BY a` or `ORDER BY cnt`).

--- a/modules/ROOT/pages/errors/gql-errors/index.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/index.adoc
@@ -1409,7 +1409,7 @@ Status description:: error: syntax error or access rule violation - unsupported 
 
 === xref:errors/gql-errors/42N44.adoc[42N44]
 
-Status description:: error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using `DISTINCT` or an aggregation.
+Status description:: error: syntax error or access rule violation - inaccessible variable. It is not possible to access the variable `{ <<variable>> }` declared before the `{ <<clause>> }` clause when using `{ <<groupingConstructs>> }`.
 
 === xref:errors/gql-errors/42N45.adoc[42N45]
 

--- a/modules/ROOT/partials/glossary.adoc
+++ b/modules/ROOT/partials/glossary.adoc
@@ -51,7 +51,7 @@
 [[graphTypeElement]]$graphTypeElement:: An element of a graph type, for example `(:Node => { name :: STRING})`, or `(:Source)-[:REL =>]->(:Target)`.
 [[graphTypeReference]]$graphTypeReference:: Graph type reference, for example, `(:Node =>)` or `p`.
 [[graphTypeOperation]]$graphTypeOperation:: Graph type operation, for example, one of `SET`, `ADD`, `DROP` or `ALTER`.
-[[groupingConstructs]]$groupingConstructs:: Constructs that establish a grouping and thereby restrict which variables remain accessible, for example, `` DISTINCT, an aggregation, or a GROUP BY clause ``.
+[[groupingConstructs]]$groupingConstructs:: Constructs that establish a grouping and thereby restrict which variables remain accessible, for example, `DISTINCT`, an aggregation, or a `GROUP BY` clause.
 [[hint]]$hint:: Freeform description of a hint, for example, `USING INDEX n:N(prop)`.
 [[hintList]]$hintList:: A list of free form descriptions of hints like `USING INDEX n:N(prop)`.
 [[ident]]$ident:: A generic identifier, for example `my_identifier`.

--- a/modules/ROOT/partials/glossary.adoc
+++ b/modules/ROOT/partials/glossary.adoc
@@ -51,6 +51,7 @@
 [[graphTypeElement]]$graphTypeElement:: An element of a graph type, for example `(:Node => { name :: STRING})`, or `(:Source)-[:REL =>]->(:Target)`.
 [[graphTypeReference]]$graphTypeReference:: Graph type reference, for example, `(:Node =>)` or `p`.
 [[graphTypeOperation]]$graphTypeOperation:: Graph type operation, for example, one of `SET`, `ADD`, `DROP` or `ALTER`.
+[[groupingConstructs]]$groupingConstructs:: Constructs that establish a grouping and thereby restrict which variables remain accessible, for example, `` DISTINCT, an aggregation, or a GROUP BY clause ``.
 [[hint]]$hint:: Freeform description of a hint, for example, `USING INDEX n:N(prop)`.
 [[hintList]]$hintList:: A list of free form descriptions of hints like `USING INDEX n:N(prop)`.
 [[ident]]$ident:: A generic identifier, for example `my_identifier`.


### PR DESCRIPTION
Updated `42N44` to reflect the introduction of the `GROUP BY` clause. Added examples.

[Monorepo PR](https://github.com/neo-technology/neo4j/pull/38319)