### PR TITLE
Introduces 42I80 invalid grouping element

### DIFF
--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -299,6 +299,7 @@
 **** xref:errors/gql-errors/42I74.adoc[]
 **** xref:errors/gql-errors/42I75.adoc[]
 **** xref:errors/gql-errors/42I78.adoc[]
+**** xref:errors/gql-errors/42I80.adoc[]
 **** xref:errors/gql-errors/42N00.adoc[]
 **** xref:errors/gql-errors/42N01.adoc[]
 **** xref:errors/gql-errors/42N02.adoc[]

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -1,0 +1,90 @@
+= 42I80
+
+== Status description
+error: syntax error or access rule violation - invalid grouping element. The grouping element '{ <<expr>> }' is not a valid grouping key. { <<cause>> }
+
+== Explanation
+A grouping element that references a projection item alias (a name introduced by a return item of the same `WITH` or `RETURN` clause) must reference it as a simple variable — the bare alias on its own.
+A non-simple reference to an alias, such as a property access, a function call, or an arithmetic expression, is not a valid grouping element.
+A grouping element can also never reference an aggregation result, since an aggregation is computed per group and cannot itself be a grouping key.
+
+== Example scenario
+
+Try projecting `b AS a`, so that `a` is a projection item alias that shadows the incoming `a`, and then grouping by `a.p` — a property access on that alias:
+
+[source,cypher]
+----
+UNWIND [{a: {p: 1}, b: 20}, {a: {p: 2}, b: 10}] AS row
+WITH row.a AS a, row.b AS b
+RETURN b AS a, count(*) AS cnt
+  GROUP BY a.p;
+----
+
+Because `a` is a projection item alias, the only valid way to group by it is the simple reference `a`; the property access `a.p` is not a valid grouping element.
+The query returns an error with GQLSTATUS 42I80 and status description:
+
+.GQLSTATUS error
+[source, error]
+----
+42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference.
+----
+
+A second form of this error occurs when a grouping element references an aggregation result. Try grouping by the aggregation alias `cnt`:
+
+[source,cypher]
+----
+UNWIND [{a: 1}, {a: 2}] AS row
+WITH row.a AS a
+RETURN a, count(*) AS cnt
+  GROUP BY a, cnt;
+----
+
+The query returns an error with GQLSTATUS 42I80 and status description:
+
+.GQLSTATUS error
+[source, error]
+----
+42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`.
+----
+
+== Possible solutions
+
+To resolve the first example, the preferred way is to reference the alias as a simple variable:
+
+.Group by the alias as a simple variable
+[source, cypher]
+----
+UNWIND [{a: {p: 1}, b: 20}, {a: {p: 2}, b: 10}] AS row
+WITH row.a AS a, row.b AS b
+RETURN b AS a, count(*) AS cnt
+  GROUP BY a;
+----
+
+To group on the incoming value, rename the projection item so it no longer shadows the incoming variable, then group by that expression:
+
+.Avoid shadowing the incoming variable
+[source, cypher]
+----
+UNWIND [{a: {p: 1}, b: 20}, {a: {p: 2}, b: 10}] AS row
+WITH row.a AS a, row.b AS b
+RETURN b AS bb, count(*) AS cnt
+  GROUP BY a.p;
+----
+
+For the second example, remove the aggregation result from the grouping elements:
+
+.Group only by non-aggregating expressions
+[source, cypher]
+----
+UNWIND [{a: 1}, {a: 2}] AS row
+WITH row.a AS a
+RETURN a, count(*) AS cnt
+  GROUP BY a;
+----
+
+ifndef::backend-pdf[]
+[discrete.glossary]
+== Glossary
+
+include::partial$glossary.adoc[]
+endif::[]

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -4,7 +4,7 @@
 error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. `{ <<cause>> }`
 
 == Explanation
-The `GROUP BY` clause is used to group the results of a query by one or more expressions.
+The `GROUP BY` clause is used to group the results of a clause by one or more expressions.
 Each expression in the `GROUP BY` clause is called a grouping element.
 
 * A grouping element may reference an alias introduced by the same `WITH` or `RETURN` clause only if the grouping element is exactly that alias.

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -1,7 +1,7 @@
 = 42I80
 
 == Status description
-error: syntax error or access rule violation - invalid grouping element. The grouping element '{ <<expr>> }' is not a valid grouping key. { <<cause>> }
+error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. { <<cause>> }
 
 == Explanation
 A grouping element that references a projection item alias (a name introduced by a return item of the same `WITH` or `RETURN` clause) must reference it as a simple variable — the bare alias on its own.
@@ -12,6 +12,7 @@ A grouping element can also never reference an aggregation result, since an aggr
 
 Let's take the following example scenarios:
 
+=== Invalid grouping on projection item alias
 
 Try projecting `b AS a`, so that `a` is a projection item alias that shadows the incoming `a`, and then grouping by `a.p` — a property access on that alias:
 
@@ -32,27 +33,7 @@ The query returns an error with GQLSTATUS 42I80 and status description:
 42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference.
 ----
 
-===  Grouping element references an aggregation result
-
-Try grouping by the aggregation alias `cnt`:
-
-[source,cypher]
-----
-UNWIND [{a: 1}, {a: 2}] AS row
-WITH row.a AS a
-RETURN a, count(*) AS cnt
-  GROUP BY a, cnt;
-----
-
-The query returns an error with GQLSTATUS 42I80 and status description:
-
-.GQLSTATUS error
-[source, error]
-----
-42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`.
-----
-
-== Possible solutions
+==== Possible solutions
 
 To resolve the first example, the preferred way is to reference the alias as a simple variable:
 
@@ -76,7 +57,29 @@ RETURN b AS bb, count(*) AS cnt
   GROUP BY a.p;
 ----
 
-For the second example, remove the aggregation result from the grouping elements:
+===  Grouping element references an aggregation result
+
+Try grouping by the aggregation alias `cnt`:
+
+[source,cypher]
+----
+UNWIND [{a: 1}, {a: 2}] AS row
+WITH row.a AS a
+RETURN a, count(*) AS cnt
+  GROUP BY a, cnt;
+----
+
+The query returns an error with GQLSTATUS 42I80 and status description:
+
+.GQLSTATUS error
+[source, error]
+----
+42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`.
+----
+
+==== Possible solutions
+
+To resolve the error remove the aggregation result from the grouping elements:
 
 .Group only by non-aggregating expressions
 [source, cypher]

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -8,7 +8,10 @@ A grouping element that references a projection item alias (a name introduced by
 A non-simple reference to an alias, such as a property access, a function call, or an arithmetic expression, is not a valid grouping element.
 A grouping element can also never reference an aggregation result, since an aggregation is computed per group and cannot itself be a grouping key.
 
-== Example scenario
+== Example scenarios
+
+Let's take the following example scenarios:
+
 
 Try projecting `b AS a`, so that `a` is a projection item alias that shadows the incoming `a`, and then grouping by `a.p` — a property access on that alias:
 
@@ -29,7 +32,9 @@ The query returns an error with GQLSTATUS 42I80 and status description:
 42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference.
 ----
 
-A second form of this error occurs when a grouping element references an aggregation result. Try grouping by the aggregation alias `cnt`:
+===  Grouping element references an aggregation result
+
+Try grouping by the aggregation alias `cnt`:
 
 [source,cypher]
 ----

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -4,9 +4,12 @@
 error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. `{ <<cause>> }`
 
 == Explanation
-A grouping element that references a projection item alias (a name introduced by a return item of the same `WITH` or `RETURN` clause) must reference it as a simple variable — the bare alias on its own.
-A non-simple reference to an alias, such as a property access, a function call, or an arithmetic expression, is not a valid grouping element.
-A grouping element can also never reference an aggregation result, since an aggregation is computed per group and cannot itself be a grouping key.
+The `GROUP BY` clause is used to group the results of a query by one or more expressions.
+Each expression in the `GROUP BY` clause is called a grouping element.
+
+* A grouping element may reference an alias introduced by the same `WITH` or `RETURN` clause only if the grouping element is exactly that alias.
+* A non-simple grouping element, such as a property access, a function call, or an arithmetic expression, cannot contain an alias.
+* A grouping element cannot contain an aggregation result, since aggregations are computed per group and cannot be grouping keys.
 
 == Example scenarios
 
@@ -33,9 +36,8 @@ The query returns an error with GQLSTATUS 42I80 and status description:
 42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference.
 ----
 
-==== Possible solutions
 
-To resolve the first example, the preferred way is to reference the alias as a simple variable:
+To fix the query, the preferred way is to reference the alias as a simple variable:
 
 .Group by the alias as a simple variable
 [source, cypher]
@@ -77,7 +79,6 @@ The query returns an error with GQLSTATUS 42I80 and status description:
 42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`.
 ----
 
-==== Possible solutions
 
 To resolve the error remove the aggregation result from the grouping elements:
 

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -28,12 +28,15 @@ RETURN b AS a, count(*) AS cnt
 ----
 
 Because `a` is a projection item alias, the only valid way to group by it is the simple reference `a`; the property access `a.p` is not a valid grouping element.
-The query returns an error with GQLSTATUS 42I80 and status description:
+The query returns a chain of errors where GQLSTATUS 42I80 is the cause of GQLSTATUS xref:errors/gql-errors/42001.adoc[42001]:
 
-.GQLSTATUS error
+.GQLSTATUS error chain
 [source, error]
 ----
-42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference.
+42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'a.p' is not a valid grouping key. A grouping element that references the projection item alias `a` must be a simple variable reference. (line 4, column 13 (offset: 126))
+"  GROUP BY a.p"
+             ^
+  42001: syntax error or access rule violation - invalid syntax
 ----
 
 
@@ -71,12 +74,15 @@ RETURN a, count(*) AS cnt
   GROUP BY a, cnt;
 ----
 
-The query returns an error with GQLSTATUS 42I80 and status description:
+The query returns a chain of errors where GQLSTATUS 42I80 is the cause of GQLSTATUS xref:errors/gql-errors/42001.adoc[42001]:
 
-.GQLSTATUS error
+.GQLSTATUS error chain
 [source, error]
 ----
-42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`.
+42I80: syntax error or access rule violation - invalid grouping element. The grouping element 'cnt' is not a valid grouping key. A grouping element cannot reference the aggregation `cnt`. (line 4, column 15 (offset: 87))
+"  GROUP BY a, cnt"
+               ^
+  42001: syntax error or access rule violation - invalid syntax
 ----
 
 

--- a/modules/ROOT/pages/errors/gql-errors/42I80.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/42I80.adoc
@@ -1,7 +1,7 @@
 = 42I80
 
 == Status description
-error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. { <<cause>> }
+error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. `{ <<cause>> }`
 
 == Explanation
 A grouping element that references a projection item alias (a name introduced by a return item of the same `WITH` or `RETURN` clause) must reference it as a simple variable — the bare alias on its own.

--- a/modules/ROOT/pages/errors/gql-errors/index.adoc
+++ b/modules/ROOT/pages/errors/gql-errors/index.adoc
@@ -1211,6 +1211,10 @@ Status description:: error: syntax error or access rule violation - index or con
 
 Status description:: error: syntax error or access rule violation - unsupported procedure or function in language version. The procedure or function is available in `CYPHER { <<version>> }`. Consider changing the database default Cypher version using `ALTER DATABASE SET DEFAULT LANGUAGE` or prefix the query with `CYPHER { <<version>> }`.
 
+=== xref:errors/gql-errors/42I80.adoc[42I80]
+
+Status description:: error: syntax error or access rule violation - invalid grouping element. The grouping element `{ <<expr>> }` is not a valid grouping key. `{ <<cause>> }`
+
 === xref:errors/gql-errors/42N00.adoc[42N00]
 
 Status description:: error: syntax error or access rule violation - graph reference not found. A graph reference with the name `{ <<db>> }` was not found. Verify that the spelling is correct.


### PR DESCRIPTION
Part of implementation CIP-236 GROUP BY.

[Monorepo PR](https://github.com/neo-technology/neo4j/pull/38319)