### PR TITLE
Add notification 01N84 for retired planner version.

### DIFF
--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1309,6 +1309,65 @@ Upgrade your client to a version that supports this type.
 ======
 =====
 
+[#_neo_clientnotification_statement_plannerversionunsupportedwarning]
+=== Retired planner version
+
+.Notification details
+[cols="<1s,<4"]
+|===
+|Neo4j  code
+m|Neo.ClientNotification.Statement.PlannerVersionUnsupportedWarning
+|Title
+a|The requested planner version is retired and no longer supported.
+|Description
+|The Cypher planner version is retired. The default planner version is used instead.
+|Category
+m|UNSUPPORTED
+|GQLSTATUS code
+m|01N84
+|Status description
+a|warn: retired planner version. The Cypher planner version { <<preparserInput>> } is retired. The default planner version is used instead.
+|Classification
+m|UNSUPPORTED
+|SeverityLevel
+m|WARNING
+|===
+
+.Requesting a retired planner version
+[.tabbed-example]
+=====
+[.include-with-GQLSTATUS-code]
+======
+Query::
++
+[source,cypher]
+----
+CYPHER plannerVersion=v2026_03 RETURN 1 AS result
+----
+
+Returned GQLSTATUS code::
+01N84
+
+Returned status description::
+warn: retired planner version. The Cypher planner version 'v2026_03' is retired. The default planner version is used instead.
+Suggestions for improvement::
+Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
+======
+[.include-with-neo4j-code]
+======
+Query::
+
+[source,cypher]
+----
+CYPHER plannerVersion=v2026_03 RETURN 1 AS result
+----
+Description of the returned code::
+The Cypher planner version 'v2026_03' is retired. The default planner version is used instead.
+Suggestions for improvement::
+Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
+======
+=====
+
 
 [#_deprecated_notifications]
 == `DEPRECATION` notifications

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1326,7 +1326,7 @@ m|UNSUPPORTED
 |GQLSTATUS code
 m|01N84
 |Status description
-a|warn: unsupported planner version. The Cypher planner version { <<preparserInput>> } is no longer supported. The default planner version is used instead.
+a|warn: unsupported planner version. The Cypher planner version `{ <<value>> }` is no longer supported. The default planner version is used instead.
 |Classification
 m|UNSUPPORTED
 |SeverityLevel
@@ -1349,7 +1349,7 @@ Returned GQLSTATUS code::
 01N84
 
 Returned status description::
-warn: unsupported planner version. The Cypher planner version 'v2026_03' is no longer supported. The default planner version is used instead.
+warn: unsupported planner version. The Cypher planner version v2026_03 is no longer supported. The default planner version is used instead.
 Suggestions for improvement::
 Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
 ======
@@ -1362,7 +1362,7 @@ Query::
 CYPHER plannerVersion=v2026_03 RETURN 1 AS result
 ----
 Description of the returned code::
-The Cypher planner version 'v2026_03' is no longer supported. The default planner version is used instead.
+The Cypher planner version v2026_03 is no longer supported. The default planner version is used instead.
 Suggestions for improvement::
 Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
 ======

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1351,7 +1351,7 @@ Returned GQLSTATUS code::
 Returned status description::
 warn: unsupported planner version. The Cypher planner version v2026_03 is no longer supported. The default planner version is used instead.
 Suggestions for improvement::
-Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
+Remove the `plannerVersion` option if the issue for which it was introduced has been resolved, or contact Neo4j support.
 ======
 [.include-with-neo4j-code]
 ======

--- a/modules/ROOT/pages/notifications/all-notifications.adoc
+++ b/modules/ROOT/pages/notifications/all-notifications.adoc
@@ -1310,7 +1310,7 @@ Upgrade your client to a version that supports this type.
 =====
 
 [#_neo_clientnotification_statement_plannerversionunsupportedwarning]
-=== Retired planner version
+=== Unsupported planner version
 
 .Notification details
 [cols="<1s,<4"]
@@ -1318,22 +1318,22 @@ Upgrade your client to a version that supports this type.
 |Neo4j  code
 m|Neo.ClientNotification.Statement.PlannerVersionUnsupportedWarning
 |Title
-a|The requested planner version is retired and no longer supported.
+a|The requested planner version is no longer supported.
 |Description
-|The Cypher planner version is retired. The default planner version is used instead.
+|The Cypher planner version is no longer supported. The default planner version is used instead.
 |Category
 m|UNSUPPORTED
 |GQLSTATUS code
 m|01N84
 |Status description
-a|warn: retired planner version. The Cypher planner version { <<preparserInput>> } is retired. The default planner version is used instead.
+a|warn: unsupported planner version. The Cypher planner version { <<preparserInput>> } is no longer supported. The default planner version is used instead.
 |Classification
 m|UNSUPPORTED
 |SeverityLevel
 m|WARNING
 |===
 
-.Requesting a retired planner version
+.Requesting an unsupported planner version
 [.tabbed-example]
 =====
 [.include-with-GQLSTATUS-code]
@@ -1349,7 +1349,7 @@ Returned GQLSTATUS code::
 01N84
 
 Returned status description::
-warn: retired planner version. The Cypher planner version 'v2026_03' is retired. The default planner version is used instead.
+warn: unsupported planner version. The Cypher planner version 'v2026_03' is no longer supported. The default planner version is used instead.
 Suggestions for improvement::
 Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
 ======
@@ -1362,7 +1362,7 @@ Query::
 CYPHER plannerVersion=v2026_03 RETURN 1 AS result
 ----
 Description of the returned code::
-The Cypher planner version 'v2026_03' is retired. The default planner version is used instead.
+The Cypher planner version 'v2026_03' is no longer supported. The default planner version is used instead.
 Suggestions for improvement::
 Remove the `plannerVersion` option to use the default planner version, or specify a supported planner version.
 ======


### PR DESCRIPTION
Documents the UNSUPPORTED notification raised when a query requests a retired Cypher planner version and the engine falls back to the default planner (Neo.ClientNotification.Statement.PlannerVersionUnsupportedWarning).